### PR TITLE
Add missing Gemini model entry

### DIFF
--- a/config.py
+++ b/config.py
@@ -22,7 +22,7 @@ class Config:
     
     # Model mappings
     PROVIDER_MODELS = {
-        "gemini": ["gemini-2.5-flash", "gemini-2.5-flash"],
+        "gemini": ["gemini-2.5-flash", "gemini-1.5-pro"],
         "openai": ["gpt-3.5-turbo", "gpt-4", "gpt-4-turbo"]
     }
     


### PR DESCRIPTION
## Summary
- update Gemini provider models to include the gemini-1.5-pro model and remove duplicate entries

## Testing
- `pytest -q` *(fails: AttributeError: module 'controller' has no attribute 'genai')*

------
https://chatgpt.com/codex/tasks/task_e_689616652ff8832b8f4596c811ada760