### PR TITLE
Fix difflib dependency name

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ piexif>=1.1.3
 pandas>=1.3.0
 
 # For improved text processing
-difflib2>=0.1.0
+difflib>=0.1.0


### PR DESCRIPTION
## Summary
- replace `difflib2` with `difflib` in requirements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689618b3c744832bb90c31be6d053763